### PR TITLE
First version of new feature to inject large file paths into linkmaze

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "quixotic"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "actix-web",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quixotic"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
This PR adds an additional option to linkmaze:
- When the optional parameter --large-file-path specifies a URL pointing to a large file (preferably a ZIP bomb as described, e.g. in https://idiallo.com/blog/zipbomb-protection), then
- with probability specified in --large-file-percent, once per page, this path is injected as a link instead of a random one pointing back to the link maze.

I serve this in nginx with a config file snippet

    # Always serve a precompressed file from its compressed form (the uncompressed
    # resume.txt file must exist, but can be empty), but uncompress on-the-fly if
    # the client doesn't indicate that they can deal with gzipped data.
    location /resume.txt {
        root   /usr/share/nginx/html;
        gzip_static  always;
        gzip_proxied expired no-cache no-store private auth;
        gunzip       on;

        limit_rate 1k;
        limit_rate_after 10;
    }

resume.txt is indeed an empty file, but resume.txt.gz is 10MB of gzip (-9) compressed /dev/zero.